### PR TITLE
Внести правки в пайплайн

### DIFF
--- a/replay_benchmarks/configs/dataset/megamarket.yaml
+++ b/replay_benchmarks/configs/dataset/megamarket.yaml
@@ -10,6 +10,6 @@ dataset:
 
   preprocess:
     global_split_ratio: 0.1
-    max_num_test_interactions: 10
+    max_num_test_interactions: Null
     min_users_per_item: 5
     min_items_per_user: 3

--- a/replay_benchmarks/configs/dataset/movielens_1m.yaml
+++ b/replay_benchmarks/configs/dataset/movielens_1m.yaml
@@ -10,6 +10,7 @@ dataset:
 
   preprocess:
     global_split_ratio: 0.1
-    max_num_test_interactions: 10
+    max_num_test_interactions: Null
     min_users_per_item: 5
     min_items_per_user: 3
+    min_rating: 3

--- a/replay_benchmarks/configs/dataset/movielens_20m.yaml
+++ b/replay_benchmarks/configs/dataset/movielens_20m.yaml
@@ -10,6 +10,7 @@ dataset:
 
   preprocess:
     global_split_ratio: 0.1
-    max_num_test_interactions: 10
+    max_num_test_interactions: Null
     min_users_per_item: 5
     min_items_per_user: 3
+    min_rating: 3

--- a/replay_benchmarks/configs/dataset/netflix.yaml
+++ b/replay_benchmarks/configs/dataset/netflix.yaml
@@ -10,6 +10,7 @@ dataset:
 
   preprocess:
     global_split_ratio: 0.1
-    max_num_test_interactions: 10
+    max_num_test_interactions: Null
     min_users_per_item: 5
     min_items_per_user: 3
+    min_rating: 3

--- a/replay_benchmarks/configs/dataset/zvuk.yaml
+++ b/replay_benchmarks/configs/dataset/zvuk.yaml
@@ -10,6 +10,6 @@ dataset:
 
   preprocess:
     global_split_ratio: 0.1
-    max_num_test_interactions: 10
+    max_num_test_interactions: Null
     min_users_per_item: 5
     min_items_per_user: 3


### PR DESCRIPTION
- отфильтровать рейтинги <= 3 для movielens и netflix
- не ограничивать длину последовательностей на валидации и тесте
- для датасета megamarket берем только покупки